### PR TITLE
Nested Shortcodes

### DIFF
--- a/css/shortcodes.css
+++ b/css/shortcodes.css
@@ -991,17 +991,17 @@ div.image-caption p:first-child {
   font-weight: bold;
 }
 
-.buttongroup-color-blue {
+.buttongroup-color-primary {
   background-color: #01578b;
 }
 
-.buttongroup-color-blue a.button {
+.buttongroup-color-primary a.button {
   background-color: #0277bd;
   color: #fff !important;
 }
 
-.buttongroup-color-blue a.button:hover,
-.buttongroup-color-blue a.button:focus {
+.buttongroup-color-primary a.button:hover,
+.buttongroup-color-primary a.button:focus {
   background-color: #026dae;
   background-color: #026baa;
   -webkit-box-shadow: 0 2px 5px rgba(0, 0, 0, 0.3);
@@ -1009,7 +1009,7 @@ div.image-caption p:first-child {
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.3);
 }
 
-.buttongroup-color-blue a.button:active {
+.buttongroup-color-primary a.button:active {
   -webkit-box-shadow: 0 3px 15px rgba(0, 0, 0, 0.35);
   -moz-box-shadow: 0 3px 15px rgba(0, 0, 0, 0.35);
   box-shadow: 0 3px 15px rgba(0, 0, 0, 0.35);

--- a/src/Plugin/Shortcode/ButtonGroupShortcode.php
+++ b/src/Plugin/Shortcode/ButtonGroupShortcode.php
@@ -1,9 +1,10 @@
 <?php
 
 namespace Drupal\ucb_migration_shortcodes\Plugin\Shortcode;
-
 use Drupal\Core\Language\Language;
 use Drupal\shortcode\Plugin\ShortcodeBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Render\RendererInterface;
 
 /**
  * The buttongroup shortcode.
@@ -14,6 +15,27 @@ use Drupal\shortcode\Plugin\ShortcodeBase;
  * )
  */
 class ButtonGroupShortcode extends ShortcodeBase {
+
+    protected $renderer;
+
+  /**
+   * Constructs a ButtonShortcode object.
+   *
+   * @param \Drupal\Core\Render\RendererInterface $renderer
+   *   The renderer service.
+   */
+  public function __construct(RendererInterface $renderer) {
+    $this->renderer = $renderer;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $container->get('renderer')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -28,12 +50,68 @@ class ButtonGroupShortcode extends ShortcodeBase {
       $attributes
     );
 
+    // Process nested shortcodes in the text content manually.
+    $processed_text = $this->processNestedShortcodes($text, $langcode);
+
     $output = [
       '#theme' => 'shortcode_buttongroup',
-      '#text' => $text,
+      '#text' => $processed_text,
       '#color' => $attributes['color'],
       '#size' => $attributes['size'],
     ];
     return $this->render($output);
   }
+/**
+   * Process nested shortcodes manually.
+   *
+   * @param string $text
+   *   The text containing shortcodes.
+   * @param string $langcode
+   *   The language code.
+   *
+   * @return string
+   *   The processed text with shortcodes rendered.
+   */
+  // Simple shortcode processing logic.
+  protected function processNestedShortcodes($text, $langcode) {
+    $shortcode_tags = [
+      // Here's where we can put allowed shortcodes
+      'icon' => 'Drupal\ucb_migration_shortcodes\Plugin\Shortcode\IconShortcode',
+    ];
+
+    foreach ($shortcode_tags as $tag => $class) {
+      $pattern = '/\[' . $tag . '([^\]]*)\](.*?)\[\/' . $tag . '\]/';
+      if (preg_match_all($pattern, $text, $matches, PREG_SET_ORDER)) {
+        foreach ($matches as $match) {
+          $attributes = $this->parseAttributes($match[1]);
+          $content = $match[2];
+          $shortcode = new $class();
+          $render_array = $shortcode->process($attributes, $content, $langcode);
+          $replacement = $this->renderer->renderRoot($render_array);
+          $text = str_replace($match[0], $replacement, $text);
+        }
+      }
+    }
+
+    return $text;
+  }
+
+  /**
+   * Parse shortcode attributes.
+   *
+   * @param string $attribute_string
+   *   The attribute string.
+   *
+   * @return array
+   *   The parsed attributes.
+   */
+  protected function parseAttributes($attribute_string) {
+    $attributes = [];
+    preg_match_all('/(\w+)=["\']?((?:.(?!["\']?\s+(?:\S+)=|[>"\']))+.)["\']?/', $attribute_string, $matches, PREG_SET_ORDER);
+    foreach ($matches as $match) {
+      $attributes[$match[1]] = $match[2];
+    }
+    return $attributes;
+  }
 }
+

--- a/src/Plugin/Shortcode/ButtonGroupShortcode.php
+++ b/src/Plugin/Shortcode/ButtonGroupShortcode.php
@@ -76,6 +76,7 @@ class ButtonGroupShortcode extends ShortcodeBase {
   protected function processNestedShortcodes($text, $langcode) {
     $shortcode_tags = [
       // Here's where we can put allowed shortcodes
+      'button' => 'Drupal\ucb_migration_shortcodes\Plugin\Shortcode\ButtonShortcode',
       'icon' => 'Drupal\ucb_migration_shortcodes\Plugin\Shortcode\IconShortcode',
     ];
 
@@ -114,4 +115,3 @@ class ButtonGroupShortcode extends ShortcodeBase {
     return $attributes;
   }
 }
-

--- a/src/Plugin/Shortcode/ButtonShortcode.php
+++ b/src/Plugin/Shortcode/ButtonShortcode.php
@@ -4,6 +4,8 @@ namespace Drupal\ucb_migration_shortcodes\Plugin\Shortcode;
 
 use Drupal\Core\Language\Language;
 use Drupal\shortcode\Plugin\ShortcodeBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Render\RendererInterface;
 
 /**
  * The button shortcode.
@@ -14,6 +16,32 @@ use Drupal\shortcode\Plugin\ShortcodeBase;
  * )
  */
 class ButtonShortcode extends ShortcodeBase {
+
+  /**
+   * The renderer service.
+   *
+   * @var \Drupal\Core\Render\RendererInterface
+   */
+  protected $renderer;
+
+  /**
+   * Constructs a ButtonShortcode object.
+   *
+   * @param \Drupal\Core\Render\RendererInterface $renderer
+   *   The renderer service.
+   */
+  public function __construct(RendererInterface $renderer) {
+    $this->renderer = $renderer;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $container->get('renderer')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -27,20 +55,77 @@ class ButtonShortcode extends ShortcodeBase {
       'style' => '',
       'size' => '',
       'icon' => '',
-    ],
-      $attributes
-    );
+    ], $attributes);
+
+    // Process nested shortcodes in the text content manually.
+    $processed_text = $this->processNestedShortcodes($text, $langcode);
 
     $output = [
       '#theme' => 'shortcode_button',
       '#link' => $attributes['url'],
-      '#title' => $text,
-      '#text' => $text,
+      '#title' => strip_tags($processed_text),
+      '#text' => [
+        '#markup' => $processed_text,
+      ],
       '#color' => $attributes['color'],
       '#style' => $attributes['style'],
       '#size' => $attributes['size'],
       '#ico' => $attributes['icon'],
     ];
-    return $this->render($output);
+
+    return $this->renderer->renderRoot($output);
+  }
+
+  /**
+   * Process nested shortcodes manually.
+   *
+   * @param string $text
+   *   The text containing shortcodes.
+   * @param string $langcode
+   *   The language code.
+   *
+   * @return string
+   *   The processed text with shortcodes rendered.
+   */
+  // Simple shortcode processing logic.
+  protected function processNestedShortcodes($text, $langcode) {
+    $shortcode_tags = [
+      // Here's where we can put allowed shortcodes
+      'icon' => 'Drupal\ucb_migration_shortcodes\Plugin\Shortcode\IconShortcode',
+    ];
+
+    foreach ($shortcode_tags as $tag => $class) {
+      $pattern = '/\[' . $tag . '([^\]]*)\](.*?)\[\/' . $tag . '\]/';
+      if (preg_match_all($pattern, $text, $matches, PREG_SET_ORDER)) {
+        foreach ($matches as $match) {
+          $attributes = $this->parseAttributes($match[1]);
+          $content = $match[2];
+          $shortcode = new $class();
+          $render_array = $shortcode->process($attributes, $content, $langcode);
+          $replacement = $this->renderer->renderRoot($render_array);
+          $text = str_replace($match[0], $replacement, $text);
+        }
+      }
+    }
+
+    return $text;
+  }
+
+  /**
+   * Parse shortcode attributes.
+   *
+   * @param string $attribute_string
+   *   The attribute string.
+   *
+   * @return array
+   *   The parsed attributes.
+   */
+  protected function parseAttributes($attribute_string) {
+    $attributes = [];
+    preg_match_all('/(\w+)=["\']?((?:.(?!["\']?\s+(?:\S+)=|[>"\']))+.)["\']?/', $attribute_string, $matches, PREG_SET_ORDER);
+    foreach ($matches as $match) {
+      $attributes[$match[1]] = $match[2];
+    }
+    return $attributes;
   }
 }

--- a/src/Plugin/Shortcode/ColumnListShortcode.php
+++ b/src/Plugin/Shortcode/ColumnListShortcode.php
@@ -4,6 +4,8 @@ namespace Drupal\ucb_migration_shortcodes\Plugin\Shortcode;
 
 use Drupal\Core\Language\Language;
 use Drupal\shortcode\Plugin\ShortcodeBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Render\RendererInterface;
 
 /**
  * Creat a box for content with a title and text area.
@@ -14,7 +16,30 @@ use Drupal\shortcode\Plugin\ShortcodeBase;
  * )
  */
 class ColumnListShortcode extends ShortcodeBase {
+  /**
+   * The renderer service.
+   *
+   * @var \Drupal\Core\Render\RendererInterface
+   */
+  protected $renderer;
 
+    /**
+   * Constructs a ColumnList object.
+   *
+   * @param \Drupal\Core\Render\RendererInterface $renderer
+   *   The renderer service.
+   */
+  public function __construct(RendererInterface $renderer) {
+    $this->renderer = $renderer;
+  }
+    /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $container->get('renderer')
+    );
+  }
   /**
    * {@inheritdoc}
    */
@@ -27,11 +52,67 @@ class ColumnListShortcode extends ShortcodeBase {
       $attributes
     );
 
+    // Process nested shortcodes in the text content manually.
+    $processed_text = $this->processNestedShortcodes($text, $langcode);
+
     $output = [
       '#theme' => 'shortcode_columnlist',
       '#columns' => $attributes['columns'],
-      '#text' => $text,
+      '#text' => $processed_text,
     ];
     return $this->render($output);
+  }
+/**
+   * Process nested shortcodes manually.
+   *
+   * @param string $text
+   *   The text containing shortcodes.
+   * @param string $langcode
+   *   The language code.
+   *
+   * @return string
+   *   The processed text with shortcodes rendered.
+   */
+  // Simple shortcode processing logic.
+  protected function processNestedShortcodes($text, $langcode) {
+    $shortcode_tags = [
+      // Here's where we can put allowed shortcodes
+      'button' => 'Drupal\ucb_migration_shortcodes\Plugin\Shortcode\ButtonShortcode',
+      'icon' => 'Drupal\ucb_migration_shortcodes\Plugin\Shortcode\IconShortcode',
+    ];
+
+    foreach ($shortcode_tags as $tag => $class) {
+      $pattern = '/\[' . $tag . '([^\]]*)\](.*?)\[\/' . $tag . '\]/';
+      if (preg_match_all($pattern, $text, $matches, PREG_SET_ORDER)) {
+        foreach ($matches as $match) {
+          $attributes = $this->parseAttributes($match[1]);
+          $content = $match[2];
+          $shortcode = new $class();
+          $render_array = $shortcode->process($attributes, $content, $langcode);
+          $replacement = $this->renderer->renderRoot($render_array);
+          $text = str_replace($match[0], $replacement, $text);
+        }
+      }
+    }
+
+    return $text;
+  }
+
+  /**
+   * Parse shortcode attributes.
+   *
+   * @param string $attribute_string
+   *   The attribute string.
+   *
+   * @return array
+   *   The parsed attributes.
+   */
+  protected function parseAttributes($attribute_string) {
+    $attributes = [];
+    preg_match_all('/(\w+)=["\']?((?:.(?!["\']?\s+(?:\S+)=|[>"\']))+.)["\']?/', $attribute_string, $matches, PREG_SET_ORDER);
+    foreach ($matches as $match) {
+      $attributes[$match[1]] = $match[2];
+    }
+    return $attributes;
   }
 }

--- a/templates/shortcode-button.html.twig
+++ b/templates/shortcode-button.html.twig
@@ -9,7 +9,7 @@
  * - color: The button color.
  * - style: The style of the button.
  * - ico: A FA icon if chosen.
- * - title: The button title attribute. 
+ * - title: The button title attribute.
  * - text: The button text.
  */
 #}
@@ -18,5 +18,5 @@
   {% if ico %}
     <i class="fa {{ ico }}"> </i>
   {% endif %}
-  {{ text|t }}
+  {{ text }}
 </a>

--- a/templates/shortcode-buttongroup.html.twig
+++ b/templates/shortcode-buttongroup.html.twig
@@ -9,9 +9,9 @@
  * - text: The buttons.
  */
 #}
-
+<p>{{color}}</p>
 <div class="buttongroup buttongroup-size-{{ size }} buttongroup-color-{{ color }}">
-	<div class="button-group-content"> 
-		{{ text|striptags('<a>')|t }}
+	<div class="button-group-content">
+		{{ text|t }}
 	</div>
 </div>

--- a/templates/shortcode-buttongroup.html.twig
+++ b/templates/shortcode-buttongroup.html.twig
@@ -9,7 +9,6 @@
  * - text: The buttons.
  */
 #}
-<p>{{color}}</p>
 <div class="buttongroup buttongroup-size-{{ size }} buttongroup-color-{{ color }}">
 	<div class="button-group-content">
 		{{ text|t }}

--- a/templates/shortcode-columnlist.html.twig
+++ b/templates/shortcode-columnlist.html.twig
@@ -11,6 +11,6 @@
 
 <div class="column-list column-list-{{ columns }}">
 	<ul>
-		{{ text|striptags('<li>')|t }}
+		{{ text|t }}
 	</ul>
 </div>

--- a/ucb_migration_shortcodes.module
+++ b/ucb_migration_shortcodes.module
@@ -102,6 +102,6 @@ function ucb_migration_shortcodes_theme() {
 }
 
 function ucb_migration_shortcodes_preprocess_page(&$variables) {
-  // Theme name: 'ucb_migration_shortcodes', library name: 'shortcodes-library'. 
+  // Theme name: 'ucb_migration_shortcodes', library name: 'shortcodes-library'.
   $variables['#attached']['library'][] = 'ucb_migration_shortcodes/shortcodes-library';
 }


### PR DESCRIPTION
Previously complex nesting of shortcodes would often break the intended  display. This adjusts the `Button`, `ButtonGroup` and `ColumnList` shortcodes to allow these complex nesting.

Other container-style shortcodes like `Box`, `Column` or `Expandable Content` seem to not need this adjustment and work as expected once the child shortcodes have been adjusted.

Resolves #21
Resolves #23 