### PR TITLE
Expandable Color Consistency

### DIFF
--- a/css/shortcodes.css
+++ b/css/shortcodes.css
@@ -187,6 +187,7 @@
 .expand-set a.expand-title {
   font-size: 110%;
   line-height: 1.4em;
+  color: inherit;
 }
 
 .expand-set a.expand-active>.fa-square-minus,
@@ -196,6 +197,7 @@
 
 .expand-set a.expand-active {
   font-weight: bold;
+  color: inherit;
 }
 
 .expand-set .expand-content {


### PR DESCRIPTION
### Expandable Blocks (Legacy Shortcode and Expandable Content Block)
- `Expandable` legacy shortcode style now mirrors `Expandable Content` Block
- Horizontal inactive tabs on the `Expandable Content` block fixed to inherit color as well.  

Includes:
- `theme` => https://github.com/CuBoulder/tiamat-theme/pull/1034
- `migration_shortcodes` => https://github.com/CuBoulder/ucb_migration_shortcodes/pull/25

Resolves https://github.com/CuBoulder/tiamat-theme/issues/767