### PR TITLE
Fixes Button Shortcode breaking LB

### DIFF
--- a/src/Plugin/Shortcode/ButtonShortcode.php
+++ b/src/Plugin/Shortcode/ButtonShortcode.php
@@ -73,7 +73,7 @@ class ButtonShortcode extends ShortcodeBase {
       '#ico' => $attributes['icon'],
     ];
 
-    return $this->renderer->renderRoot($output);
+    return $this->renderer->render($output);
   }
 
   /**
@@ -102,7 +102,7 @@ class ButtonShortcode extends ShortcodeBase {
           $content = $match[2];
           $shortcode = new $class();
           $render_array = $shortcode->process($attributes, $content, $langcode);
-          $replacement = $this->renderer->renderRoot($render_array);
+          $replacement = $this->renderer->render($render_array);
           $text = str_replace($match[0], $replacement, $text);
         }
       }


### PR DESCRIPTION
### Button Shortcode
`renderRoot` causes problems with CKEditor5 and custom plugins, while `render` seems to work fine without any Layout Builder breakage. This specifically affects Buttons, Button Group seemed to be unaffected. May require further testing of Shortcode/CKEditor5 custom plugin interactions

Resolves #28 