### PR TITLE
Revert "Fixes Button Shortcode breaking LB"

### DIFF
--- a/src/Plugin/Shortcode/ButtonShortcode.php
+++ b/src/Plugin/Shortcode/ButtonShortcode.php
@@ -73,7 +73,7 @@ class ButtonShortcode extends ShortcodeBase {
       '#ico' => $attributes['icon'],
     ];
 
-    return $this->renderer->render($output);
+    return $this->renderer->renderRoot($output);
   }
 
   /**
@@ -102,7 +102,7 @@ class ButtonShortcode extends ShortcodeBase {
           $content = $match[2];
           $shortcode = new $class();
           $render_array = $shortcode->process($attributes, $content, $langcode);
-          $replacement = $this->renderer->render($render_array);
+          $replacement = $this->renderer->renderRoot($render_array);
           $text = str_replace($match[0], $replacement, $text);
         }
       }


### PR DESCRIPTION
Reverts CuBoulder/ucb_migration_shortcodes#29

We are reverting so that we don't break Mike's migration work for the new method of migrating shortcodes.

This fix was originally for 10.3 but will no longer be needed since we are moving away from using shortcodes entirely.

**We will need to inform the UI/UX team that if they have any shortcodes on their sites they will need to delete them in 10.3 as they will no longer work and stop pages from saving.**