### PR TITLE
Updates give button shortcode to prepare for migration to plugin

### DIFF
--- a/src/Plugin/Shortcode/GiveShortcode.php
+++ b/src/Plugin/Shortcode/GiveShortcode.php
@@ -20,6 +20,33 @@ class GiveShortcode extends ShortcodeBase {
    */
   public function process(array $attributes, $text, $langcode = Language::LANGCODE_NOT_SPECIFIED) {
 
+    $color = 'black';
+    $style = 'default';
+    $size = 'regular';
+
+    $userColor = $attributes['color'];
+    $userStyle = $attributes['style'];
+    $userSize = $attributes['size'];
+
+    if ($userColor == 'dark') {
+      $color = 'black';
+    }
+    if ($userColor == 'light') {
+      $color = 'white';
+    }
+    if ($userColor == 'gold') {
+      $color = $userColor;
+    }
+    if ($userStyle == 'regular') {
+      $style = 'default';
+    }
+    if ($userStyle == 'full') {
+      $style = $userStyle;
+    }
+    if ($userSize == 'small' || $userSize == 'large') {
+      $size = $userSize;
+    }
+
     // Merge with default attributes.
     $attributes = $this->getAttributes([
       'url' => '',
@@ -36,9 +63,9 @@ class GiveShortcode extends ShortcodeBase {
       '#link' => $attributes['url'],
       '#title' => $text,
       '#text' => $text,
-      '#color' => $attributes['color'],
-      '#style' => $attributes['style'],
-      '#size' => $attributes['size'],
+      '#color' => $color,
+      '#style' => $style,
+      '#size' => $size,
       '#ico' => $attributes['icon'],
     ];
     return $this->render($output);

--- a/templates/shortcode-blockquote.html.twig
+++ b/templates/shortcode-blockquote.html.twig
@@ -12,9 +12,6 @@
 #}	
 
 
-<blockquote class="cu-blockquote margin-bottom float-{{ float }} text-{{ style }} "> 
-	{% if icon %}
-		<i class="fa {{ icon }}"> </i>
-	{% endif %}
+<blockquote> 
     {{text|t}}
-    </blockquote>
+</blockquote>

--- a/templates/shortcode-box.html.twig
+++ b/templates/shortcode-box.html.twig
@@ -30,7 +30,7 @@
 {% endif %}
 
 
-{% set correctedTitle = "none" %}
+{% set correctedTitle = "hidden" %}
 {% if title %} 
     {% set correctedTitle = "left" %}
 {% endif %}

--- a/templates/shortcode-box.html.twig
+++ b/templates/shortcode-box.html.twig
@@ -12,23 +12,14 @@
  */
 #}	
 
-{% if color == "lightgray" %}
-	{% set bgColor = "gray-light" %}
-{% elseif color == "darkgray" %}
-	{% set bgColor = "gray-dark" %}
-{% elseif color == "black" %}
-	{% set bgColor = "black" %}
-{% else %}
-	{% set bgColor = "white" %}
+{% set correctedStyle = style %}
+{% if style == "border" } 
+	{% set correctedStyle = "outline" %}
 {% endif %}
 
-{% if style == "filled" %}
-	<div class="cu-box margin-bottom box-{{ color }} float-{{ float }} {{ style }} background-{{ bgColor }}">
-{% else %}
-	<div class="cu-box margin-bottom box-{{ color }} float-{{ float }} {{ style }} border-{{ bgColor }}">
-{% endif %}
-	{% if title %}
-		<div class="box-title padding ">{{ title|t }}</div>
-	{% endif %}
-	<div class="box-content padding clearfix">{{ text|t }}</div>
+<div class="ucb-box ucb-box-title-left ucb-box-alignment-{{ float }} ucb-box-style-{{ correctedStyle }} ucb-box-theme-{{ color }}">
+	<div class="ucb-box-inner">
+		<div class="ucb-box-title">{{ title|t }}</div>
+		<div class="ucb-box-content">{{ text|t }}</div>
+	</div>
 </div>

--- a/templates/shortcode-box.html.twig
+++ b/templates/shortcode-box.html.twig
@@ -22,9 +22,9 @@
     {% set correctedColor = color %}
 {% endif %}
 
-{% set correctedStyle = "filled" %}
+{% set correctedStyle = "fill" %}
 {% if style == "filled" %} 
-    {% set correctedStyle = "filled" %}
+    {% set correctedStyle = "fill" %}
 {% elseif style == "border" %} 
     {% set correctedStyle = "outline" %}
 {% endif %}

--- a/templates/shortcode-box.html.twig
+++ b/templates/shortcode-box.html.twig
@@ -17,7 +17,14 @@
 	{% set correctedStyle = "outline" %}
 {% endif %}
 
-<div class="ucb-box ucb-box-title-left ucb-box-alignment-{{ float }} ucb-box-style-{{ correctedStyle }} ucb-box-theme-{{ color }}">
+
+{% set correctedTitle = "none" %}
+{% if title  %} 
+	{% set correctedTitle = "left" %}
+{% endif %}
+
+	
+<div class="ucb-box ucb-box-title-{{ correctedTitle }} ucb-box-alignment-{{ float }} ucb-box-style-{{ correctedStyle }} ucb-box-theme-{{ color }}">
 	<div class="ucb-box-inner">
 		<div class="ucb-box-title">{{ title|t }}</div>
 		<div class="ucb-box-content">{{ text|t }}</div>

--- a/templates/shortcode-box.html.twig
+++ b/templates/shortcode-box.html.twig
@@ -10,23 +10,35 @@
  * - style
  * - float
  */
-#}	
+#}  
 
-{% set correctedStyle = style %}
-{% if style == "border" } 
-	{% set correctedStyle = "outline" %}
+{% set correctedFloat = "none" %}
+{% if float in ["none", "left", "right"] %} 
+    {% set correctedFloat = float %}
+{% endif %}
+
+{% set correctedColor = "lightgray" %}
+{% if color in ["lightgray", "darkgray", "black", "white"] %} 
+    {% set correctedColor = color %}
+{% endif %}
+
+{% set correctedStyle = "filled" %}
+{% if float == "filled" %} 
+    {% set correctedStyle = "filled" %}
+{% elseif style == "border" } 
+    {% set correctedStyle = "outline" %}
 {% endif %}
 
 
 {% set correctedTitle = "none" %}
 {% if title  %} 
-	{% set correctedTitle = "left" %}
+    {% set correctedTitle = "left" %}
 {% endif %}
 
-	
-<div class="ucb-box ucb-box-title-{{ correctedTitle }} ucb-box-alignment-{{ float }} ucb-box-style-{{ correctedStyle }} ucb-box-theme-{{ color }}">
-	<div class="ucb-box-inner">
-		<div class="ucb-box-title">{{ title|t }}</div>
-		<div class="ucb-box-content">{{ text|t }}</div>
-	</div>
+    
+<div class="ucb-box ucb-box-title-{{ correctedTitle }} ucb-box-alignment-{{ float }} ucb-box-style-{{ correctedStyle }} ucb-box-theme-{{ correctedColor }}">
+    <div class="ucb-box-inner">
+        <div class="ucb-box-title">{{ title|t }}</div>
+        <div class="ucb-box-content">{{ text|t }}</div>
+    </div>
 </div>

--- a/templates/shortcode-box.html.twig
+++ b/templates/shortcode-box.html.twig
@@ -31,7 +31,7 @@
 {% endif %}
 <div class="ucb-box ucb-box-title-{{ correctedTitle }} ucb-box-alignment-{{ correctedFloat }} ucb-box-style-{{ correctedStyle }} ucb-box-theme-{{ correctedColor }}">
     <div class="ucb-box-inner">
-        <div class="ucb-box-title">{{ title|t }}</div>
-        <div class="ucb-box-content">{{ text|t }}</div>
+        <div class="ucb-box-title">{{ title|raw }}</div>
+        <div class="ucb-box-content">{{ text|raw }}</div>
     </div>
 </div>

--- a/templates/shortcode-box.html.twig
+++ b/templates/shortcode-box.html.twig
@@ -10,23 +10,23 @@
  * - style
  * - float
  */
-#}  
+#}
 {% set correctedFloat = "none" %}
-{% if float in ["none", "left", "right"] %} 
+{% if float in ["none", "left", "right"] %}
     {% set correctedFloat = float %}
 {% endif %}
 {% set correctedColor = "lightgray" %}
-{% if color in ["lightgray", "darkgray", "black", "white"] %} 
+{% if color in ["lightgray", "darkgray", "black", "white"] %}
     {% set correctedColor = color %}
 {% endif %}
 {% set correctedStyle = "fill" %}
-{% if style == "filled" %} 
+{% if style == "filled" %}
     {% set correctedStyle = "fill" %}
-{% elseif style == "border" %} 
+{% elseif style == "border" %}
     {% set correctedStyle = "outline" %}
 {% endif %}
 {% set correctedTitle = "hidden" %}
-{% if title %} 
+{% if title %}
     {% set correctedTitle = "left" %}
 {% endif %}
 <div class="ucb-box ucb-box-title-{{ correctedTitle }} ucb-box-alignment-{{ correctedFloat }} ucb-box-style-{{ correctedStyle }} ucb-box-theme-{{ correctedColor }}">

--- a/templates/shortcode-box.html.twig
+++ b/templates/shortcode-box.html.twig
@@ -31,7 +31,7 @@
 
 
 {% set correctedTitle = "none" %}
-{% if title  %} 
+{% if title %} 
     {% set correctedTitle = "left" %}
 {% endif %}
 

--- a/templates/shortcode-box.html.twig
+++ b/templates/shortcode-box.html.twig
@@ -11,31 +11,24 @@
  * - float
  */
 #}  
-
 {% set correctedFloat = "none" %}
 {% if float in ["none", "left", "right"] %} 
     {% set correctedFloat = float %}
 {% endif %}
-
 {% set correctedColor = "lightgray" %}
 {% if color in ["lightgray", "darkgray", "black", "white"] %} 
     {% set correctedColor = color %}
 {% endif %}
-
 {% set correctedStyle = "fill" %}
 {% if style == "filled" %} 
     {% set correctedStyle = "fill" %}
 {% elseif style == "border" %} 
     {% set correctedStyle = "outline" %}
 {% endif %}
-
-
 {% set correctedTitle = "hidden" %}
 {% if title %} 
     {% set correctedTitle = "left" %}
 {% endif %}
-
-    
 <div class="ucb-box ucb-box-title-{{ correctedTitle }} ucb-box-alignment-{{ correctedFloat }} ucb-box-style-{{ correctedStyle }} ucb-box-theme-{{ correctedColor }}">
     <div class="ucb-box-inner">
         <div class="ucb-box-title">{{ title|t }}</div>

--- a/templates/shortcode-box.html.twig
+++ b/templates/shortcode-box.html.twig
@@ -25,7 +25,7 @@
 {% set correctedStyle = "filled" %}
 {% if float == "filled" %} 
     {% set correctedStyle = "filled" %}
-{% elseif style == "border" } 
+{% elseif style == "border" %} 
     {% set correctedStyle = "outline" %}
 {% endif %}
 

--- a/templates/shortcode-box.html.twig
+++ b/templates/shortcode-box.html.twig
@@ -23,7 +23,7 @@
 {% endif %}
 
 {% set correctedStyle = "filled" %}
-{% if float == "filled" %} 
+{% if style == "filled" %} 
     {% set correctedStyle = "filled" %}
 {% elseif style == "border" %} 
     {% set correctedStyle = "outline" %}
@@ -36,7 +36,7 @@
 {% endif %}
 
     
-<div class="ucb-box ucb-box-title-{{ correctedTitle }} ucb-box-alignment-{{ float }} ucb-box-style-{{ correctedStyle }} ucb-box-theme-{{ correctedColor }}">
+<div class="ucb-box ucb-box-title-{{ correctedTitle }} ucb-box-alignment-{{ correctedFloat }} ucb-box-style-{{ correctedStyle }} ucb-box-theme-{{ correctedColor }}">
     <div class="ucb-box-inner">
         <div class="ucb-box-title">{{ title|t }}</div>
         <div class="ucb-box-content">{{ text|t }}</div>

--- a/templates/shortcode-countdown.html.twig
+++ b/templates/shortcode-countdown.html.twig
@@ -9,8 +9,14 @@
  * - background (solid/transparent)
  * - size (regular/full)
  */
-#}	
+#}
 
-<div aria-hidden="true" class="cu-countdown countdown-{{ style }} countdown-{{ size }} countdown-{{ background }}">
-	{{ text|t }}
-</div>
+{% if style is empty %}
+{% set style = 'inline'%}
+{% endif %}
+
+{% if background is empty %}
+{% set background = 'transparent'%}
+{% endif %}
+
+<span class="ucb-countdown countdown-{{ style }} countdown-{{ background }}" aria-hidden="true">{{ text|t }}</span>

--- a/templates/shortcode-give.html.twig
+++ b/templates/shortcode-give.html.twig
@@ -24,5 +24,5 @@
 
 
   <a class="ucb-link-button ucb-link-button-{{ bgColor }} ucb-link-button-{{ size }} ucb-link-button-{{ style }}" href="{{ link }}">
-    <span class="ucb-link-button-contents">{{ text|t }}</span>
+    <span class="ucb-link-button-contents">{{ text|raw }}</span>
   </a>

--- a/templates/shortcode-give.html.twig
+++ b/templates/shortcode-give.html.twig
@@ -23,8 +23,6 @@
 {% endif %}
 
 
-<p>
   <a class="ucb-link-button ucb-link-button-{{ bgColor }} ucb-link-button-{{ size }} ucb-link-button-{{ style }}" href="{{ link }}">
     <span class="ucb-link-button-contents">{{ text|t }}</span>
   </a>
-</p>

--- a/templates/shortcode-give.html.twig
+++ b/templates/shortcode-give.html.twig
@@ -18,11 +18,15 @@
   {% set bgColor = "gold" %}
 {% endif %}
 
-{% if style == "regular" %}
+{% if (style is empty) or (style == "regular")  %}
   {% set style = "default" %}
 {% endif %}
 
+{% if size is empty %}
+  {% set size = "regular" %}
+{% endif %}
 
-  <a class="ucb-link-button ucb-link-button-{{ bgColor }} ucb-link-button-{{ size }} ucb-link-button-{{ style }}" href="{{ link }}">
-    <span class="ucb-link-button-contents">{{ text|raw }}</span>
-  </a>
+
+<a class="ucb-link-button ucb-link-button-{{ bgColor }} ucb-link-button-{{ size }} ucb-link-button-{{ style }}" href="{{ link }}">
+  <span class="ucb-link-button-contents">{{ text|raw }}</span>
+</a>

--- a/templates/shortcode-give.html.twig
+++ b/templates/shortcode-give.html.twig
@@ -11,14 +11,20 @@
 #}
 
 {% if color == "dark" %}
-	{% set bgColor = "gray-dark" %}
+  {% set bgColor = "black" %}
 {% elseif color == "light" %}
-	{% set bgColor = "gray-light" %}
+  {% set bgColor = "gray" %}
 {% else %}
-	{% set bgColor = "gold" %}
+  {% set bgColor = "gold" %}
 {% endif %}
 
-<a href="{{ link }}" title="Donation Button" class="button cu-give-button button-{{ style }} button-{{ size }} button-{{ bgColor }}">
-	<i class="icon-cu"></i>
-	{{ text|t }}
-</a>
+{% if style == "regular" %}
+  {% set style = "default" %}
+{% endif %}
+
+
+<p>
+  <a class="ucb-link-button ucb-link-button-{{ bgColor }} ucb-link-button-{{ size }} ucb-link-button-{{ style }}" href="{{ link }}">
+    <span class="ucb-link-button-contents">{{ text|t }}</span>
+  </a>
+</p>

--- a/templates/shortcode-give.html.twig
+++ b/templates/shortcode-give.html.twig
@@ -9,7 +9,6 @@
  * - text: The button label.
  */
 #}
-
 <a class="ucb-link-button ucb-link-button-{{ color }} ucb-link-button-{{ size }} ucb-link-button-{{ style }}" href="{{ link }}">
   <span class="ucb-link-button-contents">{{ text|raw }}</span>
 </a>

--- a/templates/shortcode-give.html.twig
+++ b/templates/shortcode-give.html.twig
@@ -10,23 +10,6 @@
  */
 #}
 
-{% if color == "dark" %}
-  {% set bgColor = "black" %}
-{% elseif color == "light" %}
-  {% set bgColor = "gray" %}
-{% else %}
-  {% set bgColor = "gold" %}
-{% endif %}
-
-{% if (style is empty) or (style == "regular")  %}
-  {% set style = "default" %}
-{% endif %}
-
-{% if size is empty %}
-  {% set size = "regular" %}
-{% endif %}
-
-
-<a class="ucb-link-button ucb-link-button-{{ bgColor }} ucb-link-button-{{ size }} ucb-link-button-{{ style }}" href="{{ link }}">
+<a class="ucb-link-button ucb-link-button-{{ color }} ucb-link-button-{{ size }} ucb-link-button-{{ style }}" href="{{ link }}">
   <span class="ucb-link-button-contents">{{ text|raw }}</span>
 </a>

--- a/templates/shortcode-invisible.html.twig
+++ b/templates/shortcode-invisible.html.twig
@@ -8,6 +8,6 @@
  */
 #}
 
-<span class="element-invisible shortcode-invisible">
+<span class="sr-only">
 {{ text|t }}
 </span>

--- a/templates/shortcode-map.html.twig
+++ b/templates/shortcode-map.html.twig
@@ -8,7 +8,6 @@
  * - size
  */
 #}
-
 {% if mapfragment %}
   <ucb-map class="ucb-map ucb-campus-map ucb-map-size-{{ size }}" data-map-location="{{ mapfragment }}">&nbsp;</ucb-map>
 {% else %}

--- a/templates/shortcode-responsivetable.html.twig
+++ b/templates/shortcode-responsivetable.html.twig
@@ -9,4 +9,4 @@
 #}
 
 
-{{ text|striptags('<table><tbody><th><tr><td><img><strong><h2><h3><h4><h5><h6><col><colgroup><thead><tbody><tfoot>')|t }}
+{{ text|raw }}

--- a/templates/shortcode-responsivetable.html.twig
+++ b/templates/shortcode-responsivetable.html.twig
@@ -8,8 +8,5 @@
  */
 #}
 
-<div class="responsive-table-wrapper responsive-table-{{ breakpoint }}px">
-	<div class="responsive-table-wrapper-inner">
-		{{ text|striptags('<table><tbody><tr><td>')|t }}
-	</div>
-</div>
+
+{{ text|striptags('<table><tbody><tr><td><img>')|t }}

--- a/templates/shortcode-responsivetable.html.twig
+++ b/templates/shortcode-responsivetable.html.twig
@@ -9,4 +9,4 @@
 #}
 
 
-{{ text|striptags('<table><tbody><tr><td><img>')|t }}
+{{ text|striptags('<table><tbody><th><tr><td><img><strong><h2><h3><h4><h5><h6><col><colgroup><thead><tbody><tfoot>')|t }}


### PR DESCRIPTION
Changed html template to match the ckeditor 5 button plugin html. 

Button does not have a light gray or dark gray option so I set dark to be black and light to be gray as to emulate the same color options. 

I also added logic for style to be set to "default" instead of "regular" as there was no differentiation in D7

Resolves CuBoulder/ucb_migration_shortcodes#34