### PR TITLE
[column] and [colset] update

### DIFF
--- a/src/Plugin/Shortcode/ColsetShortcode.php
+++ b/src/Plugin/Shortcode/ColsetShortcode.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\ucb_migration_shortcodes\Plugin\Shortcode;
+
+use Drupal\Core\Language\Language;
+use Drupal\shortcode\Plugin\ShortcodeBase;
+
+/**
+ * Creat a box for content with a title and text area.
+ *
+ * @Shortcode(
+ *   id = "colset",
+ *   title = @Translation("Colset"),
+ * )
+ */
+class ColsetShortcode extends ShortcodeBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function process(array $attributes, $text, $langcode = Language::LANGCODE_NOT_SPECIFIED) {
+
+    $output = [
+      '#theme' => 'shortcode_colset',
+      '#text' => $text,
+    ];
+    return $this->render($output);
+  }
+}

--- a/templates/shortcode-colset.html.twig
+++ b/templates/shortcode-colset.html.twig
@@ -1,0 +1,11 @@
+{#
+/**
+ * @file
+ * Default theme implementation for the colset shortcode.
+ *
+ */
+#}
+
+<div class="row ucb-column-container">
+  {{ text|raw }}
+</div>

--- a/templates/shortcode-column.html.twig
+++ b/templates/shortcode-column.html.twig
@@ -10,13 +10,6 @@
  */
 #}
 
-{% if order != "last" %}
-  <div class="content-column column-{{ size }} {{ order }}">
-    {{ text|t }}
-  </div>
-{% else %}
-  <div class="content-column column-{{ size }} {{ order }}">
-    {{ text|t }}
-  </div>
-  <p class="clear-fix"></p>
-{% endif %}
+<div class="col ucb-column">
+  {{ text|t }}
+</div>

--- a/templates/shortcode-column.html.twig
+++ b/templates/shortcode-column.html.twig
@@ -11,5 +11,5 @@
 #}
 
 <div class="col ucb-column">
-  {{ text|t }}
+  {{ text|raw }}
 </div>

--- a/ucb_migration_shortcodes.module
+++ b/ucb_migration_shortcodes.module
@@ -26,6 +26,10 @@ function ucb_migration_shortcodes_theme() {
     'shortcode_column' => [
       'variables' => ['size' => NULL, 'order' => NULL, 'text' => ''],
     ],
+    // Colset.
+    'shortcode_colset' => [
+      'variables' => ['text' => ''],
+    ],
     // Expand.
     'shortcode_expand' => [
       'variables' => ['title' => NULL, 'style' => NULL, 'text' => ''],


### PR DESCRIPTION
Massively simplify the `[column]` shortcode so that it is ready for migration.
Also added the `[colset]` shortcode to handle row containers during the migration from shortcodes to ckeditor 5 plugins.

Closes #66 
Closes #72 